### PR TITLE
no ct attribute in some stations

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -141,6 +141,7 @@ def GetGenre(title, queryParamName=SC_BYGENRE, query=''):
 		url = SC_PLAY % station.get('id')
 		title = station.get('name').split(' - a SHOUTcast.com member station')[0]
 		summary = station.get('ct')
+		summary = "" if summary is None else summary
 
 		if station.get('mt') == "audio/mpeg":
 			fmt = 'mp3'


### PR DESCRIPTION
Some stations doesn't have a ct attribute so when you try to get any station list (Top500 or whatever that include a station without ct) the channel fails with the following StackTrace:

    2015-03-05 22:09:15,176 (2730) :  CRITICAL (core:572) - Exception (most recent call last):
      File "...\AppData\Local\Plex Media Server\Plug-ins\Framework.bundle\Contents\Resources\Versions\2\Python\Framework\components\runtime.py", line 843, in handle_request
        result = f(**d)
      File "...\AppData\Local\Plex Media Server\Plug-ins\Shoutcast.bundle\Contents\Code\__init__.py", line 154, in GetGenre
        if len(summary) > 0:
    TypeError: object of type 'NoneType' has no len()
